### PR TITLE
Fix exporting values which contain equals character

### DIFF
--- a/lib/twineCSV.rb
+++ b/lib/twineCSV.rb
@@ -24,7 +24,7 @@ module TwineCSV
         current_key = line[1..-2]
         dictionary[current_section][current_key] = {}
       elsif current_key.length > 0
-        lang, value = line.split("=").map(&:strip)
+        lang, value = line.split("=", 2).map(&:strip)
         langs << lang
         dictionary[current_section][current_key][lang] = value || ''
       end


### PR DESCRIPTION
Whenever the value in a Twine file contains an equals sign the line split will truncate the actual value.

For e.g. when using xliff in Android values the following line in a Twine file:
`en = Learn more at <xliff:g id="prod_gamegroup">Game Group</xliff:g>`
will be split twice resulting in the value being: `Learn more at <xliff:g id`

To fix this we're adding a field limit of 2 when splitting the string, the resulting split being done only by the first equals sign.
