### PR TITLE
Fix missing values for locale containing territory when exporting to csv

### DIFF
--- a/lib/twineCSV.rb
+++ b/lib/twineCSV.rb
@@ -36,7 +36,7 @@ module TwineCSV
 
       dictionary.each { |k, v|
         v.each { |k2, v2|
-          vlangs = langs.uniq.map(&:downcase).map { |lang| v2[lang] }
+          vlangs = langs.uniq.map { |lang| v2[lang] }
           f << "#{k};#{k2};#{vlangs.join(";")}" << "\n"
         }
       }


### PR DESCRIPTION
When building the language value mapping to write the .csv if that laguage code includes territory code like **en_CA** or **en_AU** than the downcase will transform it to en_ca and this doesn't map with the dictionary mapping built at line 29.
We can either downcase the language values at 28 or avoid downcasing altogether.
There's also a question why there would be languages in different casings in the same Twine file.
Think we could drop the uniq on this line also.